### PR TITLE
Add event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,5 @@ pickle-email-*.html
 
 # Ignore node_modules
 node_modules/
+
+db/datafile.db

--- a/controllers/events.js
+++ b/controllers/events.js
@@ -1,42 +1,32 @@
+// const createError = require('http-errors');
+const db = require('../db/db');
+const { conflict, created } = require('../helpers/response');
 
-var getAllEvents = () => {
+var getAllEvents = () => {};
 
+const addEvent = async (req, res, next) => {
+  try {
+    const { body } = req;
+    const event = await db.findOne({ _id: body._id });
+
+    if (event) {
+      return conflict(res, 'Event already exist!!');
+    }
+
+    const newDoc = await db.insert(body);
+    return created(res, newDoc);
+  } catch (error) {
+    return next(error);
+  }
 };
 
-var addEvent = () => {
+var getByActor = () => {};
 
-};
-
-
-var getByActor = () => {
-
-};
-
-
-var eraseEvents = () => {
-
-};
+var eraseEvents = () => {};
 
 module.exports = {
-	getAllEvents: getAllEvents,
-	addEvent: addEvent,
-	getByActor: getByActor,
-	eraseEvents: eraseEvents
+  getAllEvents: getAllEvents,
+  addEvent: addEvent,
+  getByActor: getByActor,
+  eraseEvents: eraseEvents,
 };
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/db/db.js
+++ b/db/db.js
@@ -1,5 +1,6 @@
-var Datastore = require('nedb');
-var db = new Datastore({
+const Datastore = require('nedb-promises');
+
+const db = Datastore.create({
   filename: 'db/datafile.db',
   autoload: true,
 });

--- a/helpers/response.js
+++ b/helpers/response.js
@@ -1,0 +1,40 @@
+const {
+  OK,
+  CONFLICT,
+  CREATED,
+  UNPROCESSABLE_ENTITY,
+} = require('http-status-codes');
+
+const conflict = (res, message) => {
+  res.status(CONFLICT).json({
+    status: CONFLICT,
+    message,
+  });
+};
+
+const created = (res, data) => {
+  res.status(CREATED).json({
+    status: CREATED,
+    data,
+  });
+};
+
+const unporecessed = (res, message) => {
+  res.status(UNPROCESSABLE_ENTITY).json({
+    status: UNPROCESSABLE_ENTITY,
+    message,
+  });
+};
+
+const ok = (res, message) => {
+  res.status(OK).json({
+    status: OK,
+    message,
+  });
+};
+
+module.exports = {
+  conflict,
+  created,
+  unporecessed,
+};

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -1,0 +1,17 @@
+const { unporecessed } = require('../helpers/response');
+
+const addEventValidation = (req, res, next) => {
+  const { type, actor, repo, _id } = req.body;
+
+  // TODO proper validation for the user input
+  if (!_id || !type || !actor || !repo) {
+    return unporecessed(res, 'Please, provide all required data');
+  }
+
+  req.body = { _id, type, actor, repo, created_at: new Date() };
+  return next();
+};
+
+module.exports = {
+  addEventValidation,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1531,6 +1531,14 @@
         }
       }
     },
+    "nedb-promises": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nedb-promises/-/nedb-promises-4.0.3.tgz",
+      "integrity": "sha512-NzepLVjy/Vgl5lvlhO6nze2O4GsPUroONP97fRZKPlIbjt6dV7Y5CXMmPQBI6H3Q6whG8kubFOQXJkMAXIUF3w==",
+      "requires": {
+        "nedb": "^1.8.0"
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mocha-multi-reporters": "^1.1.4",
     "morgan": "~1.8.1",
     "nedb": "^1.8.0",
+    "nedb-promises": "^4.0.3",
     "serve-favicon": "~2.4.2",
     "sqlite3": "^3.1.9"
   },

--- a/routes/events.js
+++ b/routes/events.js
@@ -1,7 +1,9 @@
-var express = require('express');
-var router = express.Router();
+const express = require('express');
+const { addEvent } = require('../controllers/events');
+const { addEventValidation } = require('../middleware/validation');
 
-// Routes related to event
+const router = express.Router();
 
+router.post('/', addEventValidation, addEvent);
 
 module.exports = router;


### PR DESCRIPTION
#### What does this PR do?
Allows a user to add events

#### Description of task completed
- Update nedb to nedb-promises
- Add events function
- Add response helpers
- Add some validation for add event function

#### How can this be tested?
- Make a post request to /events with a payload `{
  "_id": 123,
  "type":"x event",
  "actor":{
    "id": 234,
    "login": "login",
    "avatar_url": "link"
  },
  "repo":{
    "id": 345,
    "name": "repo name",
    "URL": "repo link"
  }
}`
- This returns a 201 status with a payload like ```
{
    "status": 201,
    "data": {
        "_id": 123,
        "type": "x event",
        "actor": {
            "id": 234,
            "login": "login",
            "avatar_url": "link"
        },
        "repo": {
            "id": 345,
            "name": "repo name",
            "url": "repo link"
        },
        "created_at": "2020-07-18T22:38:56.787Z"
    }
}``` or an error like `{
    "status": 409,
    "message": "Event already exist!!"
}` if an event with the id exists.